### PR TITLE
build c extension

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip
     - python
     - setuptools
+    - wheel
     - yajl
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
     - {{ PYTHON }} -c "import ijson; assert ijson.backend == 'yajl2_c'"
   requires:
     - pip
+    - python
 
 about:
   home: https://github.com/ICRAR/ijson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,12 @@ test:
     - pip
 
 about:
-  home: https://github.com/isagalaev/ijson
+  home: https://github.com/ICRAR/ijson
   license: BSD-3-Clause
   license_file: LICENSE.txt
   summary: Ijson is an iterative JSON parser with a standard Python iterator interface.
-  doc_url: https://github.com/isagalaev/ijson
-  dev_url: https://github.com/isagalaev/ijson
+  doc_url: https://github.com/ICRAR/ijson
+  dev_url: https://github.com/ICRAR/ijson
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
   number: 1
   script: 
     - {{ PYTHON }} -m pip install . --no-deps -vvv
+  # Remove it when yajl backend will work on windows 
   missing_dso_whitelist:
     - $RPATH/yajl.dll  # [win]
 
@@ -39,10 +40,6 @@ test:
     - pip
   commands:
     - pip check
-    # Check if yajl library is available
-    - if not exist %PREFIX%\\Library\\lib\\yajl_s.lib exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\yajl.dll exit 1  # [win]
-    - python -c "import ijson; print(ijson.backend)"
     - python -c "import ijson; assert ijson.backend == 'yajl2_c'"  # [not win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,10 @@ source:
 
 build:
   number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: 
+    - {{ PYTHON }} -m pip install . --no-deps -vvv
+  missing_dso_whitelist:
+    - $RPATH/yajl.dll  # [win]
 
 requirements:
   build:
@@ -24,7 +27,6 @@ requirements:
     - setuptools
     - wheel
     - yajl
-
   run:
     - python
     - yajl
@@ -33,16 +35,16 @@ test:
   imports:
     - ijson
     - ijson.backends
-  commands:
-    - pip check
-    - python -c "import ijson; assert ijson.backend == 'yajl2_c'"
   requires:
     - pip
-    - python
+  commands:
+    - pip check
+    - python -c "import ijson; assert ijson.backend == 'yajl2_c'"  # [not win]
 
 about:
   home: https://github.com/ICRAR/ijson
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Ijson is an iterative JSON parser with a standard Python iterator interface.
   doc_url: https://github.com/ICRAR/ijson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - ijson.backends
   commands:
     - pip check
-    - {{ PYTHON }} -c "import ijson; assert ijson.backend == 'yajl2_c'"
+    - python -c "import ijson; assert ijson.backend == 'yajl2_c'"
   requires:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -39,7 +39,7 @@ test:
 
 about:
   home: https://github.com/isagalaev/ijson
-  license: BSD 3-clause
+  license: BSD-3-Clause
   license_file: LICENSE.txt
   summary: Ijson is an iterative JSON parser with a standard Python iterator interface.
   doc_url: https://github.com/isagalaev/ijson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,11 @@ requirements:
     - pip
     - python
     - setuptools
+    - yajl
 
   run:
     - python
+    - yajl
 
 test:
   imports:
@@ -31,6 +33,7 @@ test:
     - ijson.backends
   commands:
     - pip check
+    - {{ PYTHON }} -c "import ijson; assert ijson.backend == 'yajl2_c'"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,10 @@ test:
     - pip
   commands:
     - pip check
+    # Check if yajl library is available
+    - if not exist %PREFIX%\\Library\\lib\\yajl_s.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\yajl.dll exit 1  # [win]
+    - python -c "import ijson; print(ijson.backend)"
     - python -c "import ijson; assert ijson.backend == 'yajl2_c'"  # [not win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  noarch: python
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 


### PR DESCRIPTION
The C extension is necessary for performance, and to prevent M1 macs from using a broken cffi backend